### PR TITLE
PHP 8 migration

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,27 @@
+name: Continuous integration
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  ci:
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-latest ]
+        php-version: [ '7.4', '8.0', '8.1' ]
+        include:
+          - php-version: '8.1'
+            coverage: true
+
+    steps:
+      - name: CI
+        uses: oat-sa/tao-extension-ci-action@v1
+        with:
+          php: ${{ matrix.php-version }}
+          coverage: ${{ matrix.coverage }}

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -25,3 +25,4 @@ jobs:
         with:
           php: ${{ matrix.php-version }}
           coverage: ${{ matrix.coverage }}
+          test-suites-path: test

--- a/composer.json
+++ b/composer.json
@@ -1,33 +1,33 @@
 {
     "name": "oat-sa/extension-tao-theming-platform",
-    "description" : "An extension focusing on theming the TAO Platform.",
-    "type" : "tao-extension",
-    "authors" : [
+    "description": "An extension focusing on theming the TAO Platform.",
+    "type": "tao-extension",
+    "authors": [
         {
             "name": "Open Assessment Technologies SA"
         }
     ],
-    "keywords" : [
+    "keywords": [
         "tao",
         "computer-based-assessment"
     ],
-    "homepage" : "http://www.taotesting.com",
-    "license" : [
+    "homepage": "http://www.taotesting.com",
+    "license": [
         "GPL-2.0"
     ],
-    "extra" : {
-        "tao-extension-name" : "taoThemingPlatform"
+    "extra": {
+        "tao-extension-name": "taoThemingPlatform"
     },
-    "minimum-stability" : "dev",
+    "minimum-stability": "dev",
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/extension-tao-datauri": "~2.0.0",
-        "oat-sa/generis" : ">=14.0.0",
-        "oat-sa/tao-core" : ">=47.0.0"
+        "oat-sa/generis": ">=15.22",
+        "oat-sa/tao-core": ">=50.24.6"
     },
-    "autoload" : {
-        "psr-4" : {
-            "oat\\taoThemingPlatform\\" : ""
+    "autoload": {
+        "psr-4": {
+            "oat\\taoThemingPlatform\\": ""
         }
     }
 }

--- a/test/PlatformThemingServiceTest.php
+++ b/test/PlatformThemingServiceTest.php
@@ -29,7 +29,7 @@ class PlatformThemingServiceTest extends TaoPhpUnitTestRunner
     private $service = null;
     private $tempConfig = null;
     
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         
@@ -45,7 +45,7 @@ class PlatformThemingServiceTest extends TaoPhpUnitTestRunner
         unset($service);
     }
     
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         


### PR DESCRIPTION
[ADF-1097](https://oat-sa.atlassian.net/browse/ADF-1097)
[ADF-1087](https://oat-sa.atlassian.net/browse/ADF-1087)
[ADF-1105](https://oat-sa.atlassian.net/browse/ADF-1105)

## Goal
Make the extension not dictating PHP version to easier our PHP maintenance, since the extension does not work in isolation and PHP version should be equally respected to all TAO extensions.